### PR TITLE
Add support for data type like timestamp(x) with/without time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Mock-data idea is to generate fake data in new test cluster and it is **NOT TO B
 # Dependencies
 
 + [Data Faker](https://github.com/icrowley/fake) by icrowley
-+ [Progress bar](https://github.com/vbauerster/mpb) by vbauerster, need v3.0.4
++ [Progress bar](https://github.com/vbauerster/mpb) by vbauerster, had to use v3.0.4, most of the latest version is not compatible anymore
 + [Postgres Driver](https://github.com/lib/pq) by lib/pq
 + [Go Logger](https://github.com/op/go-logging) by op/go-logging
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Mock-data idea is to generate fake data in new test cluster and it is **NOT TO B
 # Dependencies
 
 + [Data Faker](https://github.com/icrowley/fake) by icrowley
-+ [Progress bar](https://github.com/vbauerster/mpb) by vbauerster
++ [Progress bar](https://github.com/vbauerster/mpb) by vbauerster, need v3.0.4
 + [Postgres Driver](https://github.com/lib/pq) by lib/pq
 + [Go Logger](https://github.com/op/go-logging) by op/go-logging
 

--- a/core/datatype_mapper.go
+++ b/core/datatype_mapper.go
@@ -3,6 +3,9 @@ package core
 import (
 	"fmt"
 	"strings"
+	"regexp"
+	"strconv"
+	"math/rand"
 )
 
 // Data Generator
@@ -81,9 +84,7 @@ func BuildData(dt string) (interface{}, error) {
 			}
 		
 		// Generate Random timestamp without timezone
-		// Updated at 2019-06-26, Add code to support timestamp(6) without time zone
-
-		case strings.HasPrefix(dt, "timestamp without time zone"), strings.HasPrefix(dt, "timestamp(6) without time zone"):
+		case strings.HasPrefix(dt, "timestamp without time zone"):
 			if strings.HasSuffix(dt, "[]") {
 				ArrayArgs = map[string]interface{}{"fromyear": fromyear, "toyear": toyear}
 				value, err := ArrayGenerator("timestamp")
@@ -99,6 +100,28 @@ func BuildData(dt string) (interface{}, error) {
 				return value, nil
 			}
 
+		/* 
+		=== Updated at 2019-06-26 ===
+		Added below code to handle data type from timestamp(0) to timestampe(6) with/without time zone
+		The data type can be find in this doc: https://gpdb.docs.pivotal.io/5200/ref_guide/data_types.html 
+		*/
+		case regexp.MustCompile(`timestamp\([0-6]\) without time zone`).MatchString(dt), regexp.MustCompile(`timestamp\([0-6]\) with time zone`).MatchString(dt):
+			value, err := RandomTimestamp(fromyear, toyear)     // get a random timestamp with format like: 2018-04-10 01:19:22
+			if err != nil {
+				return "", fmt.Errorf("Build Timestamp[p] without timezone: %v", err)
+			}
+	    	ts_reg := regexp.MustCompile(`\([0-6]\)`)
+			decimal, _ := strconv.Atoi( strings.Split(ts_reg.FindString(dt),"")[1] )  // capture the decimal in timestamp[x]
+	    	var timestamp_decimal string
+			for i := 0; i < decimal; i++ {
+				timestamp_decimal = timestamp_decimal + strconv.Itoa(rand.Intn(9)) // use rand() to generate random decimal in timestamp
+			}
+			if len(timestamp_decimal) > 0 {
+				value = value + "." + timestamp_decimal
+			}
+			return value,nil
+		/* End of Updated */
+		
 		// Generate Random timestamp with timezone
 		case strings.HasPrefix(dt, "timestamp with time zone"):
 			if strings.HasSuffix(dt, "[]") {

--- a/core/datatype_mapper.go
+++ b/core/datatype_mapper.go
@@ -79,9 +79,11 @@ func BuildData(dt string) (interface{}, error) {
 				}
 				return value, nil
 			}
-
+		
 		// Generate Random timestamp without timezone
-		case strings.HasPrefix(dt, "timestamp without time zone"):
+		// Updated at 2019-06-26, Add code to support timestamp(6) without time zone
+
+		case strings.HasPrefix(dt, "timestamp without time zone"), strings.HasPrefix(dt, "timestamp(6) without time zone"):
 			if strings.HasSuffix(dt, "[]") {
 				ArrayArgs = map[string]interface{}{"fromyear": fromyear, "toyear": toyear}
 				value, err := ArrayGenerator("timestamp")


### PR DESCRIPTION
## What's this PR do?
Add support for data type like `timestamp(x) with/without time zone`

## Where should the reviewer start?
2 File has been updated:
  1. `core/datatype_mapper.go`: add an extra case condition on capture data type like timestamp(x) with/without time zone
  2. `README.md`: Based on the test, the latest mbp package is not compatible with the code, I try to use mbp v3.0.4 and it works, so update readme accordingly

## How should this be manually tested?
1. create a table like below:
```
create table test (
    day1 timestamp(0) without time zone,
    day2 timestamp(1) without time zone,
    day3 timestamp(2) without time zone,
    day4 timestamp(3) without time zone,
    day5 timestamp(4) without time zone,
    day6 timestamp(5) without time zone,
    day7 timestamp(6) without time zone,
    day8 timestamp(0) with time zone,
    day9 timestamp(1) with time zone,
    day10 timestamp(2) with time zone,
    day11 timestamp(3) with time zone,
    day12 timestamp(4) with time zone,
    day13 timestamp(5) with time zone,
    day14 timestamp(6) with time zone
);
```
2. Run the code to generate data
```
 ./mockd-linux_v1.2 greenplum -p 4987 -u gpadmin -t public.test -d gpadmin -n 10000
...
 4s [==================================================================================================] 100 %  (Mocking Table: public.test)
```

## Any background context you want to provide?
nope
## What are the relevant tickets?
nope
## Screenshots (if appropriate)
nope
## Questions:
- Is there a blog post?
- Does the knowledge base need an update (eg.s README)?
added some comment, the mbp package had to be v3.0.4
- Does this add new (go) dependencies which need to be added?
nope
