### PR TITLE
fix(GetConstraintsPertab): Also work with non-lowercase column names

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -320,7 +320,7 @@ FROM   (SELECT n.nspname
         FROM   pg_catalog.pg_class c, 
                pg_catalog.pg_constraint con, 
                pg_namespace n 
-        WHERE  c.oid = '%[1]s' :: regclass 
+        WHERE  c.oid = '"%[1]s"' :: regclass 
                AND conrelid = c.oid 
                AND n.oid = c.relnamespace 
                AND contype IN ( 'u', 'f', 'c', 'p' ) 


### PR DESCRIPTION
Recreation of the first state of #10, as it is my only idea how to solve #11.
Unfortunately I can not test the code as I have local Go environment.

Reasoning behind change: https://github.com/pivotal-gss/mock-data/issues/11#issuecomment-592186901