### PR TITLE
skip citext

### DIFF
--- a/datatypes.go
+++ b/datatypes.go
@@ -18,6 +18,7 @@ func SupportedDataTypes() []string {
 		"char(10),",
 		"varchar(10),",
 		"text,",
+		"citext,",
 		"inet,",
 		"macaddr,",
 		"cidr,",
@@ -65,6 +66,7 @@ func SupportedDataTypes() []string {
 		"timestamp with time zone[],",
 		"timestamp without time zone[],",
 		"text[],",
+		"citext[],",
 		"bool[],",
 		"inet[],",
 		"macaddr[],",
@@ -118,6 +120,7 @@ CREATE TABLE supported_datatypes (
   col_character                               char(10),
   col_character_varying                       varchar(10),
   col_text                                    text,
+  col_citext                                  citext,
 
   -- Network Address Type
   col_inet                                    inet,
@@ -162,7 +165,7 @@ CREATE TABLE supported_datatypes (
   col_pg_lsn                                  pg_lsn,
 
   -- txid snapshot
-  col_txid_snapshot                           txid_snapshot,
+  col_txid_snapshot                    	      txid_snapshot,
 
   -- UUID Type
   col_uuid                                    uuid,
@@ -187,6 +190,7 @@ CREATE TABLE supported_datatypes (
   col_timestamp_array                         timestamp with time zone[],
   col_timestamp_tz_array                      timestamp without time zone[],
   col_text_array                              text[],
+  col_citext_array                            citext[],
   col_bool_array                              bool[],
   col_inet_array                              inet[],
   col_macaddr_array                           macaddr[],

--- a/datatypes.go
+++ b/datatypes.go
@@ -18,7 +18,6 @@ func SupportedDataTypes() []string {
 		"char(10),",
 		"varchar(10),",
 		"text,",
-		"citext,",
 		"inet,",
 		"macaddr,",
 		"cidr,",
@@ -66,7 +65,6 @@ func SupportedDataTypes() []string {
 		"timestamp with time zone[],",
 		"timestamp without time zone[],",
 		"text[],",
-		"citext[],",
 		"bool[],",
 		"inet[],",
 		"macaddr[],",
@@ -120,7 +118,6 @@ CREATE TABLE supported_datatypes (
   col_character                               char(10),
   col_character_varying                       varchar(10),
   col_text                                    text,
-  col_citext                                  citext,
 
   -- Network Address Type
   col_inet                                    inet,
@@ -190,7 +187,6 @@ CREATE TABLE supported_datatypes (
   col_timestamp_array                         timestamp with time zone[],
   col_timestamp_tz_array                      timestamp without time zone[],
   col_text_array                              text[],
-  col_citext_array                            citext[],
   col_bool_array                              bool[],
   col_inet_array                              inet[],
   col_macaddr_array                           macaddr[],

--- a/engine.go
+++ b/engine.go
@@ -52,6 +52,8 @@ func BuildData(dt string) (interface{}, error) {
 		return buildBoolean(dt)
 	} else if strings.HasPrefix(dt, "text") { // Generate Random text
 		return buildText(dt)
+	} else if strings.HasPrefix(dt, "citext") { // Generate CiText text
+		return buildCiText(dt)
 	} else if strings.EqualFold(dt, "bytea") { // Generate Random bytea
 		return buildBytea(dt)
 	} else if StringHasPrefix(dt, floatKeywords) { // Generate Random float values
@@ -150,6 +152,15 @@ func buildText(dt string) (interface{}, error) {
 		return ArrayGenerator("text", dt, 0, 0)
 	}
 	return RandomParagraphs(), nil
+}
+
+// CiText Builder
+func buildCiText(dt string) (interface{}, error) {
+	isItArray, _ := isDataTypeAnArray(dt)
+	if isItArray {
+		return ArrayGenerator("citext", dt, 0, 0)
+	}
+	return RandomCiText(), nil
 }
 
 // Bytea builder
@@ -382,6 +393,8 @@ func randomDataByDataTypeForArray(dt, originalDt string, min, max int) (string, 
 		return RandomBit(max), nil
 	} else if dt == "text" {
 		return fake.WordsN(1), nil
+	} else if dt == "citext" {
+		return RandomCiText(), nil
 	} else if dt == "timetz" {
 		return RandomTimeTz(min, max)
 	} else if dt == "bool" {

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,15 @@ go 1.14
 
 require (
 	github.com/corpix/uarand v0.1.1 // indirect
-	github.com/go-pg/pg v8.0.7+incompatible // indirect
-	github.com/google/uuid v1.2.0 // indirect
-	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 // indirect
+	github.com/go-pg/pg v8.0.7+incompatible
+	github.com/google/uuid v1.2.0
+	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
-	github.com/schollz/progressbar/v3 v3.7.4 // indirect
-	github.com/sirupsen/logrus v1.7.0 // indirect
-	github.com/spf13/cobra v1.1.3 // indirect
-	github.com/spf13/viper v1.7.1 // indirect
+	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
+	github.com/schollz/progressbar/v3 v3.7.4
+	github.com/sirupsen/logrus v1.7.0
+	github.com/spf13/cobra v1.1.3
+	github.com/spf13/viper v1.7.1
+	gopkg.in/yaml.v2 v2.4.0
 	mellium.im/sasl v0.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 h1:Mo9W14pwbO9VfRe+ygqZ8dFbPpoIK1HFrG/zjTuQ+nc=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
@@ -123,6 +124,7 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=

--- a/mock.go
+++ b/mock.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	programName        = "mock"
-	programVersion     = "v2.7"
+	programVersion     = "v2.8"
 	ExecutionTimestamp = TimeNow()
 	Path               = fmt.Sprintf("%s/%s/%s", os.Getenv("HOME"), programName, ExecutionTimestamp)
 )

--- a/randomizer.go
+++ b/randomizer.go
@@ -141,6 +141,11 @@ func RandomParagraphs() string {
 	return fake.ParagraphsN(n)
 }
 
+// Random CiText generator
+func RandomCiText() string {
+	return strings.Title(fake.Words())
+}
+
 // Random IPv6 & IPv4 Address
 func RandomIP() string {
 	number := RandomInt(1, 9999)

--- a/sql.go
+++ b/sql.go
@@ -147,7 +147,7 @@ AND       n.nspname <> 'information_schema'
 AND       n.nspname !~ '^pg_toast' 
 AND       n.nspname <> 'gp_toolkit' 
 AND       c.relkind = 'r' 
-AND       c.relstorage IN ('a','h') 
+AND       c.relstorage IN ('a','h','c') 
 %s 
 ORDER BY  1
 `


### PR DESCRIPTION
Skip citext creation during the mocking of tables, since its not a default datatypes that comes preinstalled with postgres