### PR TITLE
Support populating foreign tables in Postgres

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -112,6 +112,10 @@ WHERE  c.relkind IN ( 'r', '' )
        AND n.nspname !~ '^gp_toolkit' 
        AND c.relkind = 'r' 
        %s 
+UNION
+SELECT foreign_table_schema as SCHEMA,
+       foreign_table_name as table
+FROM information_schema.foreign_tables
 ORDER  BY 1 
 `
 	// add where clause


### PR DESCRIPTION
Foreign data wrappers allow for querying schemas defined in external systems from within Postgres. This commit adds support for populating foreign tables in Postgres, motivated by the need for populating a clickhouse schema accessed through a particular foreign data wrapper.